### PR TITLE
controller: add initial controller implementation for operator

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -61,6 +61,8 @@ func init() {
 		defaults.OperatorHost, "Host to listen on.")
 	rootFlags.IntVar(&option.OperatorConfig.Server.Port, "server.port",
 		defaults.OperatorPort, "Port to listen on.")
+	rootFlags.IntVar(&option.OperatorConfig.WorkersCount, "workers",
+		defaults.WorkersCount, "Number of workers to run for the controller.")
 
 	// Convinces glog that Parse() has been called to avoid noisy logs.
 	// https://github.com/kubernetes/kubernetes/issues/17162#issuecomment-225596212

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -27,6 +27,7 @@ import (
 // RunOperator bootstraps the configuration for operator and then initiate controller
 // run.
 func RunOperator() {
+	// update k8s version using the client.
 	client, err := k8s.Client()
 	if err != nil {
 		glog.Fatalf("error while creating kubernetes client: %s", err)
@@ -52,9 +53,10 @@ func RunOperator() {
 		glog.Info("skipping automatic crd creation for operator")
 	}
 
+	cm := controller.MustNewControllerManager()
 	// Run operator controllers to watch for the resources created in kubernetes context
 	// and perform some action based on that.
-	if err := controller.RunOperatorControllers(); err != nil {
+	if err := cm.RunOperatorControllers(); err != nil {
 		glog.Fatalf("error while setting up controller for operator: %s", err)
 	}
 }

--- a/docs/cmdref/dgraph-operator.md
+++ b/docs/cmdref/dgraph-operator.md
@@ -27,6 +27,7 @@ dgraph-operator [flags]
       --stderrthreshold severity         logs at or above this threshold go to stderr
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --workers int                      Number of workers to run for the controller. (default 3)
 ```
 
 ### SEE ALSO

--- a/pkg/apis/dgraph.io/v1alpha1/register.go
+++ b/pkg/apis/dgraph.io/v1alpha1/register.go
@@ -106,26 +106,27 @@ func CreateCustomResourceDefinitions(clientset apiextclient.Interface) error {
 	return nil
 }
 
+var (
+	// DgraphClusterCRDSingularName is the singular name of custom resource definition
+	DgraphClusterCRDSingularName = "dgraphcluster"
+
+	// DgraphClusterCRDPluralName is the plural name of custom resource definition
+	DgraphClusterCRDPluralName = "dgraphclusters"
+
+	// DgraphClusterCRDShortNames are the abbreviated names to refer to this CRD's instances
+	DgraphClusterCRDShortNames = []string{"dc"}
+
+	// DgraphClusterCRDName is k8s represented name of the custom resource definition.
+	DgraphClusterCRDName string = DgraphClusterCRDPluralName + "." + SchemeGroupVersion.Group
+)
+
 // createDgraphClusterCRD creates a new Custom resource definition for kubernetes for type
 // DgraphCluster.
 func createDgraphClusterCRD(clientset apiextclient.Interface) error {
-	var (
-		// customResourceDefinitionSingularName is the singular name of custom resource definition
-		customResourceDefinitionSingularName = "dgraphcluster"
-
-		// customResourceDefinitionPluralName is the plural name of custom resource definition
-		customResourceDefinitionPluralName = "dgraphclusters"
-
-		// customResourceDefinitionShortNames are the abbreviated names to refer to this CRD's instances
-		customResourceDefinitionShortNames = []string{"dc"}
-
-		// crdName k8s represented name of the custom resource definition.
-		crdName = customResourceDefinitionPluralName + "." + SchemeGroupVersion.Group
-	)
 
 	res := &apiextv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: crdName,
+			Name: DgraphClusterCRDName,
 			Labels: map[string]string{
 				CustomResourceDefinitionSchemaVersionKey: CustomResourceDefinitionSchemaVersion,
 			},
@@ -144,9 +145,9 @@ func createDgraphClusterCRD(clientset apiextclient.Interface) error {
 				},
 			},
 			Names: apiextv1.CustomResourceDefinitionNames{
-				Plural:     customResourceDefinitionPluralName,
-				Singular:   customResourceDefinitionSingularName,
-				ShortNames: customResourceDefinitionShortNames,
+				Plural:     DgraphClusterCRDPluralName,
+				Singular:   DgraphClusterCRDSingularName,
+				ShortNames: DgraphClusterCRDShortNames,
 				Kind:       DgraphClusterKindDefinition,
 			},
 

--- a/pkg/apis/dgraph.io/v1alpha1/validation.go
+++ b/pkg/apis/dgraph.io/v1alpha1/validation.go
@@ -64,7 +64,6 @@ var (
 		Type:        "object",
 		Required: []string{
 			"replicas",
-			"config",
 		},
 		Properties: map[string]apiextv1.JSONSchemaProps{
 			"baseImage":       dgraphComponentProperties["baseImage"],
@@ -93,7 +92,6 @@ var (
 		Type:        "object",
 		Required: []string{
 			"replicas",
-			"config",
 		},
 		Properties: map[string]apiextv1.JSONSchemaProps{
 			"baseImage":       dgraphComponentProperties["baseImage"],

--- a/pkg/controller/dgraphcluster/controller.go
+++ b/pkg/controller/dgraphcluster/controller.go
@@ -18,27 +18,225 @@ package dgraphcluster
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	dgraphio "github.com/dgraph-io/dgraph-operator/pkg/apis/dgraph.io/v1alpha1"
 	"github.com/dgraph-io/dgraph-operator/pkg/client/clientset/versioned"
+	dgraphscheme "github.com/dgraph-io/dgraph-operator/pkg/client/clientset/versioned/scheme"
+	// nolint
+	dgraphinformer "github.com/dgraph-io/dgraph-operator/pkg/client/informers/externalversions/dgraph.io/v1alpha1"
+	listers "github.com/dgraph-io/dgraph-operator/pkg/client/listers/dgraph.io/v1alpha1"
+	"github.com/dgraph-io/dgraph-operator/pkg/defaults"
+	"github.com/dgraph-io/dgraph-operator/pkg/k8s"
+	"github.com/dgraph-io/dgraph-operator/pkg/option"
+
 	"github.com/golang/glog"
+	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 )
 
 // Controller is the controller to manage the DgraphCluster custom
 // resource created in the Kubernetes cluster.
+//
+// Controller type uses bits and pieces from here:
+// https://github.com/kubernetes/sample-controller/
 type Controller struct {
-	// kubeClient is the client interface to connect to the kube API server.
-	kubeClient kubernetes.Interface
+	// k8sClient is the client interface to connect to the kube API server.
+	k8sClient kubernetes.Interface
 
 	// dgraphClient is the client interface to interacting with dgraph related
 	// custom resources.
 	dgraphClient versioned.Interface
+
+	dgraphClusterLister listers.DgraphClusterLister
+	dgraphClusterSynced cache.InformerSynced
+
+	// workqueue is a rate limited work queue. This is used to queue work to be
+	// processed instead of performing it as soon as a change happens. This
+	// means we can ensure we only process a fixed amount of resources at a
+	// time, and makes it easy to ensure we are never processing the same item
+	// simultaneously in two different workers.
+	workqueue workqueue.RateLimitingInterface
+
+	// recorder is an event recorder for recording Event resources to the
+	// Kubernetes API.
+	recorder record.EventRecorder
 }
 
-func NewController() *Controller {
-	return &Controller{}
+// NewController returns a new DgraphCluster controller.
+func NewController(k8sClient kubernetes.Interface,
+	dgraphClient versioned.Interface,
+	dgraphClusterInformer dgraphinformer.DgraphClusterInformer) *Controller {
+
+	utilruntime.Must(dgraphscheme.AddToScheme(scheme.Scheme))
+	glog.Info("Creating event broadcaster")
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	eventBroadcaster.StartRecordingToSink(
+		&typedcorev1.
+			EventSinkImpl{Interface: k8sClient.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(
+		scheme.Scheme,
+		v1.EventSource{Component: defaults.DgraphOperatorName})
+
+	workqueue := workqueue.NewNamedRateLimitingQueue(
+		workqueue.DefaultControllerRateLimiter(),
+		"DgraphClusters")
+
+	ctrl := &Controller{
+		k8sClient:    k8sClient,
+		dgraphClient: dgraphClient,
+
+		recorder:  recorder,
+		workqueue: workqueue,
+	}
+
+	ctrl.dgraphClusterLister = dgraphClusterInformer.Lister()
+	ctrl.dgraphClusterSynced = dgraphClusterInformer.Informer().HasSynced
+
+	dgraphClusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			glog.Info("add on DgraphCluster CRD invoked.")
+			ctrl.enqueueObj(obj)
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			glog.Info("update on DgraphClsuter CRD invoked.")
+			ctrl.enqueueObj(cur)
+		},
+		DeleteFunc: func(obj interface{}) {
+			glog.Info("delete on DgraphCluster CRD invoked.")
+			ctrl.enqueueObj(obj)
+		},
+	})
+
+	return ctrl
 }
 
+// Run runs the actual underlying DgraphCluster controller.
 func (dc *Controller) Run(ctx context.Context) {
-	glog.Infof("running DgraphCluster controller")
+	glog.Info("running DgraphCluster controller")
+	defer utilruntime.HandleCrash()
+	defer dc.workqueue.ShutDown()
+
+	// Wait for CRD to be ready, skip if any error occurs.
+	if err := k8s.WaitForCRD(dgraphio.DgraphClusterCRDName); err != nil {
+		glog.Warningf("error while waiting for CRD to be ready: %s\nignoring failure", err)
+	}
+
+	glog.Info("waiting for informer cache to sync")
+	if ok := cache.WaitForCacheSync(ctx.Done(), dc.dgraphClusterSynced); !ok {
+		glog.Fatalf("error while syncing informer cache, exitting")
+	}
+	glog.Info("informer cache synced.")
+
+	// Run WorkersCount number of workers to process the work from the queue.
+	for i := 0; i < option.OperatorConfig.WorkersCount; i++ {
+		go wait.Until(dc.runWorker, time.Second, ctx.Done())
+	}
+
+	glog.Info("started workers")
+	<-ctx.Done()
+	glog.Info("shutting down workers")
+}
+
+func (dc *Controller) runWorker() {
+	for dc.processNextWorkItem() {
+		// long-running function that will continually call the
+		// processNextWorkItem function in order to read and process
+		// a message on the workqueue.
+	}
+}
+
+// process a work item from the workqueue.
+func (dc *Controller) processNextWorkItem() bool {
+	obj, shutdown := dc.workqueue.Get()
+
+	// Got shutdown when getting object from workqueue.
+	// We exit from processing the work items.
+	if shutdown {
+		return false
+	}
+
+	// We call Done here so the workqueue knows we have finished
+	// processing this item. We also must remember to call Forget if we
+	// do not want this work item being re-queued. For example, we do
+	// not call Forget if a transient error occurs, instead the item is
+	// put back on the workqueue and attempted again after a back-off
+	// period.
+	defer dc.workqueue.Done(obj)
+	var objKey string
+	var ok bool
+
+	// We expect strings to come off the workqueue. These are of the
+	// form namespace/name. We do this as the delayed nature of the
+	// workqueue means the items in the informer cache may actually be
+	// more up to date that when the item was initially put onto the
+	// workqueue.
+	if objKey, ok = obj.(string); !ok {
+		// As the item in the workqueue is actually invalid, we call
+		// Forget here else we'd go into a loop of attempting to
+		// process a work item that is invalid.
+		dc.workqueue.Forget(obj)
+		utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+		return true
+	}
+
+	// Sync the object
+	if err := dc.sync(objKey); err != nil {
+		// Put the item back on the workqueue to handle any transient errors.
+		// This item we be retried at later point of time.
+		dc.workqueue.AddRateLimited(objKey)
+		err = fmt.Errorf("error syncing '%s': %s, requeuing", objKey, err.Error())
+	} else {
+		// Finally, if no error occurs we Forget this item so it does not
+		// get queued again until another change happens.
+		dc.workqueue.Forget(obj)
+	}
+	glog.Infof("successfully synced '%s'", objKey)
+
+	return true
+}
+
+// Syncs the DgraphCluster resource represented by `key`
+func (dc *Controller) sync(key string) error {
+	startTime := time.Now()
+	defer glog.Infof("DgraphCluster sync done %q (%v)", key, time.Since(startTime))
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	// Get the DgraphCluster CRD object we are syncing here.
+	cluster, err := dc.dgraphClusterLister.DgraphClusters(namespace).Get(name)
+	if kerrors.IsNotFound(err) {
+		glog.Infof("DgraphCluster(%q) has already been deleted", key)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return dc.updateDgraphCluster(cluster.DeepCopy())
+}
+
+// enqueueObj enqueues the object to the work queue.
+func (dc *Controller) enqueueObj(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Cound't get key for object %+v: %v", obj, err))
+		return
+	}
+	glog.Infof("enqueuing %q", key)
+	dc.workqueue.Add(key)
 }

--- a/pkg/controller/dgraphcluster/update.go
+++ b/pkg/controller/dgraphcluster/update.go
@@ -14,21 +14,13 @@
  * limitations under the License.
  */
 
-package defaults
+package dgraphcluster
 
 import (
-	"time"
+	dgraphio "github.com/dgraph-io/dgraph-operator/pkg/apis/dgraph.io/v1alpha1"
 )
 
-const (
-	// CRDWaitPollInterval is the interval in which to regularly poll the K8s API server
-	// for the availability of CRD.
-	CRDWaitPollInterval time.Duration = 2 * time.Second
-
-	// K8SAPIServerRequestTimeout is the default value of timeout for the request to
-	// Kubernetes API server.
-	K8SAPIServerRequestTimeout time.Duration = 20 * time.Second
-
-	// InformerResyncDuration is the default resync duration of k8s shared informer factory.
-	InformerResyncDuration time.Duration = 30 * time.Second
-)
+// This function handles the udpate of dgraph cluster object.
+func (dc *Controller) updateDgraphCluster(dcObj *dgraphio.DgraphCluster) error {
+	return nil
+}

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -22,6 +22,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/dgraph-io/dgraph-operator/pkg/client/clientset/versioned"
+	informers "github.com/dgraph-io/dgraph-operator/pkg/client/informers/externalversions"
 	dc "github.com/dgraph-io/dgraph-operator/pkg/controller/dgraphcluster"
 	"github.com/dgraph-io/dgraph-operator/pkg/defaults"
 	"github.com/dgraph-io/dgraph-operator/pkg/k8s"
@@ -29,10 +31,19 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 )
+
+// Manager manages all the controllers for the operator.
+type Manager struct {
+	k8sClient    kubernetes.Interface
+	dgraphClient versioned.Interface
+
+	registeredControllers []Controller
+}
 
 // Controller is the standard interface which each controller within dgraph operator
 // must implement.
@@ -40,11 +51,28 @@ type Controller interface {
 	Run(context.Context)
 }
 
-var (
-	registeredControllers = []Controller{
-		dc.NewController(),
+// MustNewControllerManager returns a Manager instance if it is able
+// to do so, else it exists the program.
+func MustNewControllerManager() *Manager {
+	k8sClient, err := k8s.Client()
+	if err != nil {
+		glog.Fatalf("error while building kubernetes client.")
 	}
-)
+
+	dgraphClient, err := k8s.DgraphClient()
+	if err != nil {
+		glog.Fatalf("error while building dgraph k8s client")
+	}
+
+	registeredControllers := make([]Controller, 0)
+
+	return &Manager{
+		k8sClient,
+		dgraphClient,
+
+		registeredControllers,
+	}
+}
 
 // RunOperatorControllers runs all the required controllers for dgraph operator.
 // Each controller watches for the resources it reconciles and take necessery action
@@ -53,12 +81,7 @@ var (
 // Here we also implement the logic of leader election for dgraph operator using
 // built-in leader election capbility in kubernetes.
 // See: https://github.com/kubernetes/client-go/blob/master/examples/leader-election/main.go
-func RunOperatorControllers() error {
-	client, err := k8s.Client()
-	if err != nil {
-		return err
-	}
-
+func (cm *Manager) RunOperatorControllers() error {
 	// Get hostname for identity name of the lease lock holder.
 	// We identify the leader of the operator cluster using hostname.
 	// If there is an error while getting hostname we use a randomly generated
@@ -96,7 +119,8 @@ func RunOperatorControllers() error {
 	// and fewer objects in the cluster watch "all Leases".
 	// There is an issue with leaselocks for now which gives the following error:
 	// E0102 16:45:18.120239   24632 leaderelection.go:307] Failed to release lock:
-	//    Lease.coordination.k8s.io "dgraph-io-controller-manager" is invalid: spec.leaseDurationSeconds:
+	//    Lease.coordination.k8s.io "dgraph-io-controller-manager" is invalid:
+	// 	  spec.leaseDurationSeconds:
 	//    Invalid value: 0: must be greater than 0
 	//
 	// TODO: Use LeaseLock here.
@@ -105,7 +129,7 @@ func RunOperatorControllers() error {
 			Name:      defaults.LeaseLockName,
 			Namespace: ns,
 		},
-		Client: client.CoreV1(),
+		Client: cm.k8sClient.CoreV1(),
 		LockConfig: resourcelock.ResourceLockConfig{
 			// Identity name of theholder
 			Identity:      hostID,
@@ -123,7 +147,7 @@ func RunOperatorControllers() error {
 		RetryPeriod:   defaults.LeaderElectionRetryPeriod,
 
 		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: onStart,
+			OnStartedLeading: cm.onStart,
 			OnStoppedLeading: func() {
 				glog.Infof("leader election lost: %s", hostID)
 			},
@@ -142,12 +166,31 @@ func RunOperatorControllers() error {
 
 // onStart is the main function which is executed when our operator starts leading
 // the cluster of operators in the kubernetes cluster.
-func onStart(ctx context.Context) {
+// onStart also populates the registered controller that the operator manages.
+func (cm *Manager) onStart(ctx context.Context) {
 	glog.Info("started leading.")
+	glog.Info("registering controllers for operator")
+	defer func() {
+		cm.registeredControllers = make([]Controller, 0)
+		glog.Info("exitting onStart method...")
+	}()
 
-	// Start running managed controllers here
-	for _, ctrl := range registeredControllers {
-		go ctrl.Run(ctx)
+	dgraphClusterInformer := informers.NewSharedInformerFactory(
+		cm.dgraphClient, defaults.InformerResyncDuration)
+	cm.registeredControllers = append(cm.registeredControllers, dc.NewController(
+		cm.k8sClient,
+		cm.dgraphClient,
+		dgraphClusterInformer.Dgraph().V1alpha1().DgraphClusters(),
+	))
+
+	// notice that there is no need to run Start methods in a separate goroutine.
+	// (i.e. go informerFactory.Start(stopCh) Start method is non-blocking and
+	// runs all registered informers in a dedicated goroutine.
+	dgraphClusterInformer.Start(ctx.Done())
+
+	for _, ctrl := range cm.registeredControllers {
+		ctrl.Run(ctx)
 	}
+
 	select {}
 }

--- a/pkg/defaults/operator.go
+++ b/pkg/defaults/operator.go
@@ -21,11 +21,17 @@ import (
 )
 
 const (
+	// DgraphOperatorName is the name of the dgraph operator
+	DgraphOperatorName string = "dgraph-operator"
+
 	// OperatorHost is the default host for the operator server.
 	OperatorHost string = "0.0.0.0"
 
 	// OperatorPort is the default port that operator server listens to.
 	OperatorPort int = 7777
+
+	// WorkersCount is default number of workers to run for the operator controller.
+	WorkersCount int = 3
 
 	// LeaseLockName is the default value of lease lock we acquire when doing leader elections
 	// among the operators.

--- a/pkg/option/operator.go
+++ b/pkg/option/operator.go
@@ -37,6 +37,9 @@ type operatorConfig struct {
 	// to create the configuration for rest client.
 	KubeCfgPath string
 
+	// Workers count is the number of workers to run for the controller.
+	WorkersCount int
+
 	// server represents configuration of the operator server.
 	Server *operatorServer
 }

--- a/vendor/k8s.io/client-go/util/workqueue/default_rate_limiters.go
+++ b/vendor/k8s.io/client-go/util/workqueue/default_rate_limiters.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type RateLimiter interface {
+	// When gets an item and gets to decide how long that item should wait
+	When(item interface{}) time.Duration
+	// Forget indicates that an item is finished being retried.  Doesn't matter whether its for perm failing
+	// or for success, we'll stop tracking it
+	Forget(item interface{})
+	// NumRequeues returns back how many failures the item has had
+	NumRequeues(item interface{}) int
+}
+
+// DefaultControllerRateLimiter is a no-arg constructor for a default rate limiter for a workqueue.  It has
+// both overall and per-item rate limiting.  The overall is a token bucket and the per-item is exponential
+func DefaultControllerRateLimiter() RateLimiter {
+	return NewMaxOfRateLimiter(
+		NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
+		// 10 qps, 100 bucket size.  This is only for retry speed and its only the overall factor (not per item)
+		&BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+	)
+}
+
+// BucketRateLimiter adapts a standard bucket to the workqueue ratelimiter API
+type BucketRateLimiter struct {
+	*rate.Limiter
+}
+
+var _ RateLimiter = &BucketRateLimiter{}
+
+func (r *BucketRateLimiter) When(item interface{}) time.Duration {
+	return r.Limiter.Reserve().Delay()
+}
+
+func (r *BucketRateLimiter) NumRequeues(item interface{}) int {
+	return 0
+}
+
+func (r *BucketRateLimiter) Forget(item interface{}) {
+}
+
+// ItemExponentialFailureRateLimiter does a simple baseDelay*2^<num-failures> limit
+// dealing with max failures and expiration are up to the caller
+type ItemExponentialFailureRateLimiter struct {
+	failuresLock sync.Mutex
+	failures     map[interface{}]int
+
+	baseDelay time.Duration
+	maxDelay  time.Duration
+}
+
+var _ RateLimiter = &ItemExponentialFailureRateLimiter{}
+
+func NewItemExponentialFailureRateLimiter(baseDelay time.Duration, maxDelay time.Duration) RateLimiter {
+	return &ItemExponentialFailureRateLimiter{
+		failures:  map[interface{}]int{},
+		baseDelay: baseDelay,
+		maxDelay:  maxDelay,
+	}
+}
+
+func DefaultItemBasedRateLimiter() RateLimiter {
+	return NewItemExponentialFailureRateLimiter(time.Millisecond, 1000*time.Second)
+}
+
+func (r *ItemExponentialFailureRateLimiter) When(item interface{}) time.Duration {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	exp := r.failures[item]
+	r.failures[item] = r.failures[item] + 1
+
+	// The backoff is capped such that 'calculated' value never overflows.
+	backoff := float64(r.baseDelay.Nanoseconds()) * math.Pow(2, float64(exp))
+	if backoff > math.MaxInt64 {
+		return r.maxDelay
+	}
+
+	calculated := time.Duration(backoff)
+	if calculated > r.maxDelay {
+		return r.maxDelay
+	}
+
+	return calculated
+}
+
+func (r *ItemExponentialFailureRateLimiter) NumRequeues(item interface{}) int {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	return r.failures[item]
+}
+
+func (r *ItemExponentialFailureRateLimiter) Forget(item interface{}) {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	delete(r.failures, item)
+}
+
+// ItemFastSlowRateLimiter does a quick retry for a certain number of attempts, then a slow retry after that
+type ItemFastSlowRateLimiter struct {
+	failuresLock sync.Mutex
+	failures     map[interface{}]int
+
+	maxFastAttempts int
+	fastDelay       time.Duration
+	slowDelay       time.Duration
+}
+
+var _ RateLimiter = &ItemFastSlowRateLimiter{}
+
+func NewItemFastSlowRateLimiter(fastDelay, slowDelay time.Duration, maxFastAttempts int) RateLimiter {
+	return &ItemFastSlowRateLimiter{
+		failures:        map[interface{}]int{},
+		fastDelay:       fastDelay,
+		slowDelay:       slowDelay,
+		maxFastAttempts: maxFastAttempts,
+	}
+}
+
+func (r *ItemFastSlowRateLimiter) When(item interface{}) time.Duration {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	r.failures[item] = r.failures[item] + 1
+
+	if r.failures[item] <= r.maxFastAttempts {
+		return r.fastDelay
+	}
+
+	return r.slowDelay
+}
+
+func (r *ItemFastSlowRateLimiter) NumRequeues(item interface{}) int {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	return r.failures[item]
+}
+
+func (r *ItemFastSlowRateLimiter) Forget(item interface{}) {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	delete(r.failures, item)
+}
+
+// MaxOfRateLimiter calls every RateLimiter and returns the worst case response
+// When used with a token bucket limiter, the burst could be apparently exceeded in cases where particular items
+// were separately delayed a longer time.
+type MaxOfRateLimiter struct {
+	limiters []RateLimiter
+}
+
+func (r *MaxOfRateLimiter) When(item interface{}) time.Duration {
+	ret := time.Duration(0)
+	for _, limiter := range r.limiters {
+		curr := limiter.When(item)
+		if curr > ret {
+			ret = curr
+		}
+	}
+
+	return ret
+}
+
+func NewMaxOfRateLimiter(limiters ...RateLimiter) RateLimiter {
+	return &MaxOfRateLimiter{limiters: limiters}
+}
+
+func (r *MaxOfRateLimiter) NumRequeues(item interface{}) int {
+	ret := 0
+	for _, limiter := range r.limiters {
+		curr := limiter.NumRequeues(item)
+		if curr > ret {
+			ret = curr
+		}
+	}
+
+	return ret
+}
+
+func (r *MaxOfRateLimiter) Forget(item interface{}) {
+	for _, limiter := range r.limiters {
+		limiter.Forget(item)
+	}
+}

--- a/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"container/heap"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// DelayingInterface is an Interface that can Add an item at a later time. This makes it easier to
+// requeue items after failures without ending up in a hot-loop.
+type DelayingInterface interface {
+	Interface
+	// AddAfter adds an item to the workqueue after the indicated duration has passed
+	AddAfter(item interface{}, duration time.Duration)
+}
+
+// NewDelayingQueue constructs a new workqueue with delayed queuing ability
+func NewDelayingQueue() DelayingInterface {
+	return NewDelayingQueueWithCustomClock(clock.RealClock{}, "")
+}
+
+// NewNamedDelayingQueue constructs a new named workqueue with delayed queuing ability
+func NewNamedDelayingQueue(name string) DelayingInterface {
+	return NewDelayingQueueWithCustomClock(clock.RealClock{}, name)
+}
+
+// NewDelayingQueueWithCustomClock constructs a new named workqueue
+// with ability to inject real or fake clock for testing purposes
+func NewDelayingQueueWithCustomClock(clock clock.Clock, name string) DelayingInterface {
+	ret := &delayingType{
+		Interface:       NewNamed(name),
+		clock:           clock,
+		heartbeat:       clock.NewTicker(maxWait),
+		stopCh:          make(chan struct{}),
+		waitingForAddCh: make(chan *waitFor, 1000),
+		metrics:         newRetryMetrics(name),
+	}
+
+	go ret.waitingLoop()
+
+	return ret
+}
+
+// delayingType wraps an Interface and provides delayed re-enquing
+type delayingType struct {
+	Interface
+
+	// clock tracks time for delayed firing
+	clock clock.Clock
+
+	// stopCh lets us signal a shutdown to the waiting loop
+	stopCh chan struct{}
+	// stopOnce guarantees we only signal shutdown a single time
+	stopOnce sync.Once
+
+	// heartbeat ensures we wait no more than maxWait before firing
+	heartbeat clock.Ticker
+
+	// waitingForAddCh is a buffered channel that feeds waitingForAdd
+	waitingForAddCh chan *waitFor
+
+	// metrics counts the number of retries
+	metrics retryMetrics
+}
+
+// waitFor holds the data to add and the time it should be added
+type waitFor struct {
+	data    t
+	readyAt time.Time
+	// index in the priority queue (heap)
+	index int
+}
+
+// waitForPriorityQueue implements a priority queue for waitFor items.
+//
+// waitForPriorityQueue implements heap.Interface. The item occurring next in
+// time (i.e., the item with the smallest readyAt) is at the root (index 0).
+// Peek returns this minimum item at index 0. Pop returns the minimum item after
+// it has been removed from the queue and placed at index Len()-1 by
+// container/heap. Push adds an item at index Len(), and container/heap
+// percolates it into the correct location.
+type waitForPriorityQueue []*waitFor
+
+func (pq waitForPriorityQueue) Len() int {
+	return len(pq)
+}
+func (pq waitForPriorityQueue) Less(i, j int) bool {
+	return pq[i].readyAt.Before(pq[j].readyAt)
+}
+func (pq waitForPriorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+// Push adds an item to the queue. Push should not be called directly; instead,
+// use `heap.Push`.
+func (pq *waitForPriorityQueue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*waitFor)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+// Pop removes an item from the queue. Pop should not be called directly;
+// instead, use `heap.Pop`.
+func (pq *waitForPriorityQueue) Pop() interface{} {
+	n := len(*pq)
+	item := (*pq)[n-1]
+	item.index = -1
+	*pq = (*pq)[0:(n - 1)]
+	return item
+}
+
+// Peek returns the item at the beginning of the queue, without removing the
+// item or otherwise mutating the queue. It is safe to call directly.
+func (pq waitForPriorityQueue) Peek() interface{} {
+	return pq[0]
+}
+
+// ShutDown stops the queue. After the queue drains, the returned shutdown bool
+// on Get() will be true. This method may be invoked more than once.
+func (q *delayingType) ShutDown() {
+	q.stopOnce.Do(func() {
+		q.Interface.ShutDown()
+		close(q.stopCh)
+		q.heartbeat.Stop()
+	})
+}
+
+// AddAfter adds the given item to the work queue after the given delay
+func (q *delayingType) AddAfter(item interface{}, duration time.Duration) {
+	// don't add if we're already shutting down
+	if q.ShuttingDown() {
+		return
+	}
+
+	q.metrics.retry()
+
+	// immediately add things with no delay
+	if duration <= 0 {
+		q.Add(item)
+		return
+	}
+
+	select {
+	case <-q.stopCh:
+		// unblock if ShutDown() is called
+	case q.waitingForAddCh <- &waitFor{data: item, readyAt: q.clock.Now().Add(duration)}:
+	}
+}
+
+// maxWait keeps a max bound on the wait time. It's just insurance against weird things happening.
+// Checking the queue every 10 seconds isn't expensive and we know that we'll never end up with an
+// expired item sitting for more than 10 seconds.
+const maxWait = 10 * time.Second
+
+// waitingLoop runs until the workqueue is shutdown and keeps a check on the list of items to be added.
+func (q *delayingType) waitingLoop() {
+	defer utilruntime.HandleCrash()
+
+	// Make a placeholder channel to use when there are no items in our list
+	never := make(<-chan time.Time)
+
+	// Make a timer that expires when the item at the head of the waiting queue is ready
+	var nextReadyAtTimer clock.Timer
+
+	waitingForQueue := &waitForPriorityQueue{}
+	heap.Init(waitingForQueue)
+
+	waitingEntryByData := map[t]*waitFor{}
+
+	for {
+		if q.Interface.ShuttingDown() {
+			return
+		}
+
+		now := q.clock.Now()
+
+		// Add ready entries
+		for waitingForQueue.Len() > 0 {
+			entry := waitingForQueue.Peek().(*waitFor)
+			if entry.readyAt.After(now) {
+				break
+			}
+
+			entry = heap.Pop(waitingForQueue).(*waitFor)
+			q.Add(entry.data)
+			delete(waitingEntryByData, entry.data)
+		}
+
+		// Set up a wait for the first item's readyAt (if one exists)
+		nextReadyAt := never
+		if waitingForQueue.Len() > 0 {
+			if nextReadyAtTimer != nil {
+				nextReadyAtTimer.Stop()
+			}
+			entry := waitingForQueue.Peek().(*waitFor)
+			nextReadyAtTimer = q.clock.NewTimer(entry.readyAt.Sub(now))
+			nextReadyAt = nextReadyAtTimer.C()
+		}
+
+		select {
+		case <-q.stopCh:
+			return
+
+		case <-q.heartbeat.C():
+			// continue the loop, which will add ready items
+
+		case <-nextReadyAt:
+			// continue the loop, which will add ready items
+
+		case waitEntry := <-q.waitingForAddCh:
+			if waitEntry.readyAt.After(q.clock.Now()) {
+				insert(waitingForQueue, waitingEntryByData, waitEntry)
+			} else {
+				q.Add(waitEntry.data)
+			}
+
+			drained := false
+			for !drained {
+				select {
+				case waitEntry := <-q.waitingForAddCh:
+					if waitEntry.readyAt.After(q.clock.Now()) {
+						insert(waitingForQueue, waitingEntryByData, waitEntry)
+					} else {
+						q.Add(waitEntry.data)
+					}
+				default:
+					drained = true
+				}
+			}
+		}
+	}
+}
+
+// insert adds the entry to the priority queue, or updates the readyAt if it already exists in the queue
+func insert(q *waitForPriorityQueue, knownEntries map[t]*waitFor, entry *waitFor) {
+	// if the entry already exists, update the time only if it would cause the item to be queued sooner
+	existing, exists := knownEntries[entry.data]
+	if exists {
+		if existing.readyAt.After(entry.readyAt) {
+			existing.readyAt = entry.readyAt
+			heap.Fix(q, existing.index)
+		}
+
+		return
+	}
+
+	heap.Push(q, entry)
+	knownEntries[entry.data] = entry
+}

--- a/vendor/k8s.io/client-go/util/workqueue/doc.go
+++ b/vendor/k8s.io/client-go/util/workqueue/doc.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package workqueue provides a simple queue that supports the following
+// features:
+//  * Fair: items processed in the order in which they are added.
+//  * Stingy: a single item will not be processed multiple times concurrently,
+//      and if an item is added multiple times before it can be processed, it
+//      will only be processed once.
+//  * Multiple consumers and producers. In particular, it is allowed for an
+//      item to be reenqueued while it is being processed.
+//  * Shutdown notifications.
+package workqueue // import "k8s.io/client-go/util/workqueue"

--- a/vendor/k8s.io/client-go/util/workqueue/metrics.go
+++ b/vendor/k8s.io/client-go/util/workqueue/metrics.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+)
+
+// This file provides abstractions for setting the provider (e.g., prometheus)
+// of metrics.
+
+type queueMetrics interface {
+	add(item t)
+	get(item t)
+	done(item t)
+	updateUnfinishedWork()
+}
+
+// GaugeMetric represents a single numerical value that can arbitrarily go up
+// and down.
+type GaugeMetric interface {
+	Inc()
+	Dec()
+}
+
+// SettableGaugeMetric represents a single numerical value that can arbitrarily go up
+// and down. (Separate from GaugeMetric to preserve backwards compatibility.)
+type SettableGaugeMetric interface {
+	Set(float64)
+}
+
+// CounterMetric represents a single numerical value that only ever
+// goes up.
+type CounterMetric interface {
+	Inc()
+}
+
+// SummaryMetric captures individual observations.
+type SummaryMetric interface {
+	Observe(float64)
+}
+
+// HistogramMetric counts individual observations.
+type HistogramMetric interface {
+	Observe(float64)
+}
+
+type noopMetric struct{}
+
+func (noopMetric) Inc()            {}
+func (noopMetric) Dec()            {}
+func (noopMetric) Set(float64)     {}
+func (noopMetric) Observe(float64) {}
+
+// defaultQueueMetrics expects the caller to lock before setting any metrics.
+type defaultQueueMetrics struct {
+	clock clock.Clock
+
+	// current depth of a workqueue
+	depth GaugeMetric
+	// total number of adds handled by a workqueue
+	adds CounterMetric
+	// how long an item stays in a workqueue
+	latency HistogramMetric
+	// how long processing an item from a workqueue takes
+	workDuration         HistogramMetric
+	addTimes             map[t]time.Time
+	processingStartTimes map[t]time.Time
+
+	// how long have current threads been working?
+	unfinishedWorkSeconds   SettableGaugeMetric
+	longestRunningProcessor SettableGaugeMetric
+}
+
+func (m *defaultQueueMetrics) add(item t) {
+	if m == nil {
+		return
+	}
+
+	m.adds.Inc()
+	m.depth.Inc()
+	if _, exists := m.addTimes[item]; !exists {
+		m.addTimes[item] = m.clock.Now()
+	}
+}
+
+func (m *defaultQueueMetrics) get(item t) {
+	if m == nil {
+		return
+	}
+
+	m.depth.Dec()
+	m.processingStartTimes[item] = m.clock.Now()
+	if startTime, exists := m.addTimes[item]; exists {
+		m.latency.Observe(m.sinceInSeconds(startTime))
+		delete(m.addTimes, item)
+	}
+}
+
+func (m *defaultQueueMetrics) done(item t) {
+	if m == nil {
+		return
+	}
+
+	if startTime, exists := m.processingStartTimes[item]; exists {
+		m.workDuration.Observe(m.sinceInSeconds(startTime))
+		delete(m.processingStartTimes, item)
+	}
+}
+
+func (m *defaultQueueMetrics) updateUnfinishedWork() {
+	// Note that a summary metric would be better for this, but prometheus
+	// doesn't seem to have non-hacky ways to reset the summary metrics.
+	var total float64
+	var oldest float64
+	for _, t := range m.processingStartTimes {
+		age := m.sinceInMicroseconds(t)
+		total += age
+		if age > oldest {
+			oldest = age
+		}
+	}
+	// Convert to seconds; microseconds is unhelpfully granular for this.
+	total /= 1000000
+	m.unfinishedWorkSeconds.Set(total)
+	m.longestRunningProcessor.Set(oldest / 1000000)
+}
+
+type noMetrics struct{}
+
+func (noMetrics) add(item t)            {}
+func (noMetrics) get(item t)            {}
+func (noMetrics) done(item t)           {}
+func (noMetrics) updateUnfinishedWork() {}
+
+// Gets the time since the specified start in microseconds.
+func (m *defaultQueueMetrics) sinceInMicroseconds(start time.Time) float64 {
+	return float64(m.clock.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
+}
+
+// Gets the time since the specified start in seconds.
+func (m *defaultQueueMetrics) sinceInSeconds(start time.Time) float64 {
+	return m.clock.Since(start).Seconds()
+}
+
+type retryMetrics interface {
+	retry()
+}
+
+type defaultRetryMetrics struct {
+	retries CounterMetric
+}
+
+func (m *defaultRetryMetrics) retry() {
+	if m == nil {
+		return
+	}
+
+	m.retries.Inc()
+}
+
+// MetricsProvider generates various metrics used by the queue.
+type MetricsProvider interface {
+	NewDepthMetric(name string) GaugeMetric
+	NewAddsMetric(name string) CounterMetric
+	NewLatencyMetric(name string) HistogramMetric
+	NewWorkDurationMetric(name string) HistogramMetric
+	NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric
+	NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric
+	NewRetriesMetric(name string) CounterMetric
+}
+
+type noopMetricsProvider struct{}
+
+func (_ noopMetricsProvider) NewDepthMetric(name string) GaugeMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewAddsMetric(name string) CounterMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewLatencyMetric(name string) HistogramMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewWorkDurationMetric(name string) HistogramMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
+	return noopMetric{}
+}
+
+var globalMetricsFactory = queueMetricsFactory{
+	metricsProvider: noopMetricsProvider{},
+}
+
+type queueMetricsFactory struct {
+	metricsProvider MetricsProvider
+
+	onlyOnce sync.Once
+}
+
+func (f *queueMetricsFactory) setProvider(mp MetricsProvider) {
+	f.onlyOnce.Do(func() {
+		f.metricsProvider = mp
+	})
+}
+
+func (f *queueMetricsFactory) newQueueMetrics(name string, clock clock.Clock) queueMetrics {
+	mp := f.metricsProvider
+	if len(name) == 0 || mp == (noopMetricsProvider{}) {
+		return noMetrics{}
+	}
+	return &defaultQueueMetrics{
+		clock:                   clock,
+		depth:                   mp.NewDepthMetric(name),
+		adds:                    mp.NewAddsMetric(name),
+		latency:                 mp.NewLatencyMetric(name),
+		workDuration:            mp.NewWorkDurationMetric(name),
+		unfinishedWorkSeconds:   mp.NewUnfinishedWorkSecondsMetric(name),
+		longestRunningProcessor: mp.NewLongestRunningProcessorSecondsMetric(name),
+		addTimes:                map[t]time.Time{},
+		processingStartTimes:    map[t]time.Time{},
+	}
+}
+
+func newRetryMetrics(name string) retryMetrics {
+	var ret *defaultRetryMetrics
+	if len(name) == 0 {
+		return ret
+	}
+	return &defaultRetryMetrics{
+		retries: globalMetricsFactory.metricsProvider.NewRetriesMetric(name),
+	}
+}
+
+// SetProvider sets the metrics provider for all subsequently created work
+// queues. Only the first call has an effect.
+func SetProvider(metricsProvider MetricsProvider) {
+	globalMetricsFactory.setProvider(metricsProvider)
+}

--- a/vendor/k8s.io/client-go/util/workqueue/parallelizer.go
+++ b/vendor/k8s.io/client-go/util/workqueue/parallelizer.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"context"
+	"sync"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+type DoWorkPieceFunc func(piece int)
+
+// ParallelizeUntil is a framework that allows for parallelizing N
+// independent pieces of work until done or the context is canceled.
+func ParallelizeUntil(ctx context.Context, workers, pieces int, doWorkPiece DoWorkPieceFunc) {
+	var stop <-chan struct{}
+	if ctx != nil {
+		stop = ctx.Done()
+	}
+
+	toProcess := make(chan int, pieces)
+	for i := 0; i < pieces; i++ {
+		toProcess <- i
+	}
+	close(toProcess)
+
+	if pieces < workers {
+		workers = pieces
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer utilruntime.HandleCrash()
+			defer wg.Done()
+			for piece := range toProcess {
+				select {
+				case <-stop:
+					return
+				default:
+					doWorkPiece(piece)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/vendor/k8s.io/client-go/util/workqueue/queue.go
+++ b/vendor/k8s.io/client-go/util/workqueue/queue.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+)
+
+type Interface interface {
+	Add(item interface{})
+	Len() int
+	Get() (item interface{}, shutdown bool)
+	Done(item interface{})
+	ShutDown()
+	ShuttingDown() bool
+}
+
+// New constructs a new work queue (see the package comment).
+func New() *Type {
+	return NewNamed("")
+}
+
+func NewNamed(name string) *Type {
+	rc := clock.RealClock{}
+	return newQueue(
+		rc,
+		globalMetricsFactory.newQueueMetrics(name, rc),
+		defaultUnfinishedWorkUpdatePeriod,
+	)
+}
+
+func newQueue(c clock.Clock, metrics queueMetrics, updatePeriod time.Duration) *Type {
+	t := &Type{
+		clock:                      c,
+		dirty:                      set{},
+		processing:                 set{},
+		cond:                       sync.NewCond(&sync.Mutex{}),
+		metrics:                    metrics,
+		unfinishedWorkUpdatePeriod: updatePeriod,
+	}
+	go t.updateUnfinishedWorkLoop()
+	return t
+}
+
+const defaultUnfinishedWorkUpdatePeriod = 500 * time.Millisecond
+
+// Type is a work queue (see the package comment).
+type Type struct {
+	// queue defines the order in which we will work on items. Every
+	// element of queue should be in the dirty set and not in the
+	// processing set.
+	queue []t
+
+	// dirty defines all of the items that need to be processed.
+	dirty set
+
+	// Things that are currently being processed are in the processing set.
+	// These things may be simultaneously in the dirty set. When we finish
+	// processing something and remove it from this set, we'll check if
+	// it's in the dirty set, and if so, add it to the queue.
+	processing set
+
+	cond *sync.Cond
+
+	shuttingDown bool
+
+	metrics queueMetrics
+
+	unfinishedWorkUpdatePeriod time.Duration
+	clock                      clock.Clock
+}
+
+type empty struct{}
+type t interface{}
+type set map[t]empty
+
+func (s set) has(item t) bool {
+	_, exists := s[item]
+	return exists
+}
+
+func (s set) insert(item t) {
+	s[item] = empty{}
+}
+
+func (s set) delete(item t) {
+	delete(s, item)
+}
+
+// Add marks item as needing processing.
+func (q *Type) Add(item interface{}) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	if q.shuttingDown {
+		return
+	}
+	if q.dirty.has(item) {
+		return
+	}
+
+	q.metrics.add(item)
+
+	q.dirty.insert(item)
+	if q.processing.has(item) {
+		return
+	}
+
+	q.queue = append(q.queue, item)
+	q.cond.Signal()
+}
+
+// Len returns the current queue length, for informational purposes only. You
+// shouldn't e.g. gate a call to Add() or Get() on Len() being a particular
+// value, that can't be synchronized properly.
+func (q *Type) Len() int {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	return len(q.queue)
+}
+
+// Get blocks until it can return an item to be processed. If shutdown = true,
+// the caller should end their goroutine. You must call Done with item when you
+// have finished processing it.
+func (q *Type) Get() (item interface{}, shutdown bool) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	for len(q.queue) == 0 && !q.shuttingDown {
+		q.cond.Wait()
+	}
+	if len(q.queue) == 0 {
+		// We must be shutting down.
+		return nil, true
+	}
+
+	item, q.queue = q.queue[0], q.queue[1:]
+
+	q.metrics.get(item)
+
+	q.processing.insert(item)
+	q.dirty.delete(item)
+
+	return item, false
+}
+
+// Done marks item as done processing, and if it has been marked as dirty again
+// while it was being processed, it will be re-added to the queue for
+// re-processing.
+func (q *Type) Done(item interface{}) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	q.metrics.done(item)
+
+	q.processing.delete(item)
+	if q.dirty.has(item) {
+		q.queue = append(q.queue, item)
+		q.cond.Signal()
+	}
+}
+
+// ShutDown will cause q to ignore all new items added to it. As soon as the
+// worker goroutines have drained the existing items in the queue, they will be
+// instructed to exit.
+func (q *Type) ShutDown() {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	q.shuttingDown = true
+	q.cond.Broadcast()
+}
+
+func (q *Type) ShuttingDown() bool {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	return q.shuttingDown
+}
+
+func (q *Type) updateUnfinishedWorkLoop() {
+	t := q.clock.NewTicker(q.unfinishedWorkUpdatePeriod)
+	defer t.Stop()
+	for range t.C() {
+		if !func() bool {
+			q.cond.L.Lock()
+			defer q.cond.L.Unlock()
+			if !q.shuttingDown {
+				q.metrics.updateUnfinishedWork()
+				return true
+			}
+			return false
+
+		}() {
+			return
+		}
+	}
+}

--- a/vendor/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
+++ b/vendor/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+// RateLimitingInterface is an interface that rate limits items being added to the queue.
+type RateLimitingInterface interface {
+	DelayingInterface
+
+	// AddRateLimited adds an item to the workqueue after the rate limiter says it's ok
+	AddRateLimited(item interface{})
+
+	// Forget indicates that an item is finished being retried.  Doesn't matter whether it's for perm failing
+	// or for success, we'll stop the rate limiter from tracking it.  This only clears the `rateLimiter`, you
+	// still have to call `Done` on the queue.
+	Forget(item interface{})
+
+	// NumRequeues returns back how many times the item was requeued
+	NumRequeues(item interface{}) int
+}
+
+// NewRateLimitingQueue constructs a new workqueue with rateLimited queuing ability
+// Remember to call Forget!  If you don't, you may end up tracking failures forever.
+func NewRateLimitingQueue(rateLimiter RateLimiter) RateLimitingInterface {
+	return &rateLimitingType{
+		DelayingInterface: NewDelayingQueue(),
+		rateLimiter:       rateLimiter,
+	}
+}
+
+func NewNamedRateLimitingQueue(rateLimiter RateLimiter, name string) RateLimitingInterface {
+	return &rateLimitingType{
+		DelayingInterface: NewNamedDelayingQueue(name),
+		rateLimiter:       rateLimiter,
+	}
+}
+
+// rateLimitingType wraps an Interface and provides rateLimited re-enquing
+type rateLimitingType struct {
+	DelayingInterface
+
+	rateLimiter RateLimiter
+}
+
+// AddRateLimited AddAfter's the item based on the time when the rate limiter says it's ok
+func (q *rateLimitingType) AddRateLimited(item interface{}) {
+	q.DelayingInterface.AddAfter(item, q.rateLimiter.When(item))
+}
+
+func (q *rateLimitingType) NumRequeues(item interface{}) int {
+	return q.rateLimiter.NumRequeues(item)
+}
+
+func (q *rateLimitingType) Forget(item interface{}) {
+	q.rateLimiter.Forget(item)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -338,6 +338,7 @@ k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
+k8s.io/client-go/util/workqueue
 # k8s.io/code-generator v0.17.0
 k8s.io/code-generator
 k8s.io/code-generator/cmd/client-gen


### PR DESCRIPTION
This PR adds a higher level barebones structure for the Kubernetes cluster for the dgraph controller. This sets up the boilerplate for the controller as specified in Kubernetes sample-controller repository - https://github.com/kubernetes/sample-controller

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-operator/12)
<!-- Reviewable:end -->
